### PR TITLE
Rework config options

### DIFF
--- a/pibooth_lcd_i2c.py
+++ b/pibooth_lcd_i2c.py
@@ -59,7 +59,7 @@ def write_lcd_lines(app, specific_line_type="all"):
     """
     if hasattr(app, 'lcd'):
         try:
-            for row_index in range(app.lcd_rows):
+            for row_index in range(app.rows):
                 line_text, line_type = app.lines[row_index]
                 app.lcd.cursor_pos = (row_index, 0)
                 if line_type == 'Taken_Photo' and specific_line_type in ['all', line_type]:

--- a/pibooth_lcd_i2c.py
+++ b/pibooth_lcd_i2c.py
@@ -59,23 +59,24 @@ def write_lcd_lines(app, specific_line_type="all"):
     """
     if hasattr(app, 'lcd'):
         try:
-            for line_index, (line_text, line_type) in enumerate(app.lines):
-                app.lcd.cursor_pos = (line_index, 0)
+            for row_index in range(app.lcd_rows):
+                line_text, line_type = app.lines[row_index]
+                app.lcd.cursor_pos = (row_index, 0)
                 if line_type == 'Taken_Photo' and specific_line_type in ['all', line_type]:
                     app.lcd.write_string(line_text[:app.cols - 4])
-                    app.lcd.cursor_pos = (line_index, app.cols - 4)
+                    app.lcd.cursor_pos = (row_index, app.cols - 4)
                     app.lcd.write_string(' %s' % app.count.taken)
                 elif line_type == 'Printed' and specific_line_type in ['all', line_type]:
                     app.lcd.write_string(line_text[:app.cols - 4])
-                    app.lcd.cursor_pos = (line_index, app.cols - 4)
+                    app.lcd.cursor_pos = (row_index, app.cols - 4)
                     app.lcd.write_string(' %s' % app.count.printed)
                 elif line_type == 'Forgotten' and specific_line_type in ['all', line_type]:
                     app.lcd.write_string(line_text[:app.cols - 4])
-                    app.lcd.cursor_pos = (line_index, app.cols - 4)
+                    app.lcd.cursor_pos = (row_index, app.cols - 4)
                     app.lcd.write_string(' %s' % app.count.forgotten)
                 elif line_type == 'Remaining_Duplicates' and specific_line_type in ['all', line_type]:
                     app.lcd.write_string(line_text[:app.cols - 4])
-                    app.lcd.cursor_pos = (line_index, app.cols - 4)
+                    app.lcd.cursor_pos = (row_index, app.cols - 4)
                     app.lcd.write_string(' %s' % app.count.remaining_duplicates)
                 elif line_type == 'Date_Time' and specific_line_type in ['all', line_type]:
                     app.lcd.write_string(time.strftime(line_text))

--- a/pibooth_lcd_i2c.py
+++ b/pibooth_lcd_i2c.py
@@ -62,11 +62,11 @@ def write_lcd_lines(app, specific_line_type="all"):
             for line_index, (line_text, line_type) in enumerate(app.lines):
                 app.lcd.cursor_pos = (line_index, 0)
                 if line_type == 'Taken_Photo' and specific_line_type in ['all', line_type]:
-                    app.lcd.write_string(app.taken_photo_text[:app.cols - 4])
+                    app.lcd.write_string(line_text[:app.cols - 4])
                     app.lcd.cursor_pos = (line_index, app.cols - 4)
                     app.lcd.write_string(' %s' % app.count.taken)
                 elif line_type == 'Printed' and specific_line_type in ['all', line_type]:
-                    app.lcd.write_string(app.printed_text[:app.cols - 4])
+                    app.lcd.write_string(line_text[:app.cols - 4])
                     app.lcd.cursor_pos = (line_index, app.cols - 4)
                     app.lcd.write_string(' %s' % app.count.printed)
                 elif line_type == 'Forgotten' and specific_line_type in ['all', line_type]:

--- a/pibooth_lcd_i2c.py
+++ b/pibooth_lcd_i2c.py
@@ -17,14 +17,14 @@ def pibooth_configure(cfg):
                    "Choose LCD chip - PCF8574(Default) or MCP23008 or MCP23017")
     cfg.add_option('LCD_I2C', 'lcd_port_address', "0x3F",
                    "Change Port Address 0x3F(Default)")
-    cfg.add_option('LCD_I2C', 'lcd_port', "1", 
+    cfg.add_option('LCD_I2C', 'lcd_port', "1",
                    "Change the I2C port number 1 or 2 - (Default = 1)")
-    cfg.add_option('LCD_I2C', 'lcd_charmap', "A02", 
+    cfg.add_option('LCD_I2C', 'lcd_charmap', "A02",
                    "Change the I2C charmap A00 or A02 or ST0B - (Default = A02)")
-    cfg.add_option('LCD_I2C', 'lcd_cols', "16", 
+    cfg.add_option('LCD_I2C', 'lcd_cols', "16",
                    "Number of columns per row 16 or 20 (16 = Default on a 16x2 LCD)",
                    "Number of columns per row", ["16", "20"])
-    cfg.add_option('LCD_I2C', 'lcd_rows', "2", 
+    cfg.add_option('LCD_I2C', 'lcd_rows', "2",
                    "Number of display rows 1 or 2 or 4 - (2 = Default on a 16x2 LCD)",
                    "Number of rows", ["1", "2", "4"])
 
@@ -114,7 +114,7 @@ def pibooth_startup(app, cfg):
     # Connect the LCD to I2c portexpander
     # startup.
     connect_i2c(app, cfg)
-    
+
     # Write all lines at startup
     write_lcd_lines(app)
 

--- a/pibooth_lcd_i2c.py
+++ b/pibooth_lcd_i2c.py
@@ -13,132 +13,79 @@ __version__ = "1.1.2"
 @pibooth.hookimpl
 def pibooth_configure(cfg):
     """Declare the new configuration options"""
-    cfg.add_option('LCD_I2C', 'lcd_chip', "PCF8574", 
+    cfg.add_option('LCD_I2C', 'lcd_chip', "PCF8574",
                    "Choose LCD chip - PCF8574(Default) or MCP23008 or MCP23017")
-    cfg.add_option('LCD_I2C', 'lcd_port_address', "0x3F", 
+    cfg.add_option('LCD_I2C', 'lcd_port_address', "0x3F",
                    "Change Port Address 0x3F(Default)")
     cfg.add_option('LCD_I2C', 'lcd_port', "1", 
                    "Change the I2C port number 1 or 2 - (Default = 1)")
     cfg.add_option('LCD_I2C', 'lcd_charmap', "A02", 
                    "Change the I2C charmap A00 or A02 or ST0B - (Default = A02)")
     cfg.add_option('LCD_I2C', 'lcd_cols', "16", 
-                   "Number of columns per row 16 or 20 (16 = Default on a 16x2 LCD)")
+                   "Number of columns per row 16 or 20 (16 = Default on a 16x2 LCD)",
+                   "Number of columns per row", ["16", "20"])
     cfg.add_option('LCD_I2C', 'lcd_rows', "2", 
-                   "Number of display rows 1 or 2 or 4 - (2 = Default on a 16x2 LCD)")
-                   # Text
-    cfg.add_option('LCD_I2C', 'lcd_taken_photo_text', "Taken Photo", 
-                   "Text before taken counter is displayed - Max-12 characters on a 16x2 display - Max 16 characters on a 20x4 display")
-    cfg.add_option('LCD_I2C', 'lcd_show_date_time', "%d/%m - %H:%M:%S", 
-                   "You can change the way Date-Time is displayed - Max-16 character on a 16x2 display - Max 20 character on a 20x4 display \n# Default %d/%m - %H:%M:%S")
-    cfg.add_option('LCD_I2C', 'lcd_printed_text', "Printed", 
-                   "Text before printed counter is displayed - Max-12 characters on a 16x2 display - Max 16 characters on a 20x4 display")
-    cfg.add_option('LCD_I2C', 'lcd_forgotten_text', "Forgotten", 
-                   "Text before forgotten counter is displayed - Max-12 characters on a 16x2 display - Max 16 characters on a 20x4 display")
-    cfg.add_option('LCD_I2C', 'lcd_remaining_duplicates_text', "Duplicates", 
-                   "Text before remaining_duplicates counter is displayed - Max-12 characters on a 16x2 display - Max 16 characters on a 20x4 display")
-                   # Free Text
-    cfg.add_option('LCD_I2C', 'lcd_free_text1', "Free Text 1", 
-                   "Free Text 1 - Max-16 characters on a 16x2 display - Max 20 characters on a 20x4 display")
-    cfg.add_option('LCD_I2C', 'lcd_free_text2', "Free Text 2", 
-                   "Free Text 2 - Max-16 characters on a 16x2 display - Max 20 characters on a 20x4 display")
-    cfg.add_option('LCD_I2C', 'lcd_free_text3', "Free Text 3", 
-                   "Free Text 3 - Max-16 characters on a 16x2 display - Max 20 characters on a 20x4 display")
-    cfg.add_option('LCD_I2C', 'lcd_free_text4', "Free Text 4", 
-                   "Free Text 4 - Max-16 characters on a 16x2 display - Max 20 characters on a 20x4 display")
-                   # Line select options
-    cfg.add_option('LCD_I2C', 'lcd_line_1', "Taken_Photo", 
-                   "Choose what to display on line 1\n# 'Taken_Photo', 'Printed', 'Forgotten', 'Remaining_Duplicates', 'Date_Time', 'Free_Text_1', 'Free_Text_2', 'Free_Text_3', 'Free_Text_4'")
-    cfg.add_option('LCD_I2C', 'lcd_line_2', "Date_Time", 
-                   "Choose what to display on line 2\n# 'Taken_Photo', 'Printed', 'Forgotten', 'Remaining_Duplicates', 'Date_Time', 'Free_Text_1', 'Free_Text_2', 'Free_Text_3', 'Free_Text_4'")
-    cfg.add_option('LCD_I2C', 'lcd_line_3', " ", 
-                   "Choose what to display on line 3 ((( ONLY FOR 20x4 or 16x4 displays, otherwise leave empty )))\n# 'Taken_Photo', 'Printed', 'Forgotten', 'Remaining_Duplicates', 'Date_Time', 'Free_Text_1', 'Free_Text_2', 'Free_Text_3', 'Free_Text_4'")
-    cfg.add_option('LCD_I2C', 'lcd_line_4', " ", 
-                   "Choose what to display on line 4 ((( ONLY FOR 20x4 or 16x4 displays, otherwise leave empty )))\n# 'Taken_Photo', 'Printed', 'Forgotten', 'Remaining_Duplicates', 'Date_Time', 'Free_Text_1', 'Free_Text_2', 'Free_Text_3', 'Free_Text_4'")
+                   "Number of display rows 1 or 2 or 4 - (2 = Default on a 16x2 LCD)",
+                   "Number of rows", ["1", "2", "4"])
 
-#'Taken_Photo', 'Printed', 'Forgotten', 'Remaining_Duplicates', 'Date_Time', 'Free_text_1', 'Free_text_2', 'Free_text_3', 'Free_text_4')
+    cfg.add_option('LCD_I2C', 'lcd_line_1_text', "Taken Photo",
+                   'Line 1 text (put format code e.g. "%d/%m - %H:%M:%S" for time rendering',
+                   "Line 1 text", "Taken Photo")
+    cfg.add_option('LCD_I2C', 'lcd_line_1_type', "Taken_Photo",
+                   "Line 1 type",
+                   "Line 1 type", ['Taken_Photo', 'Printed', 'Forgotten', 'Remaining_Duplicates', 'Date_Time', 'Text'])
+    cfg.add_option('LCD_I2C', 'lcd_line_2_text', "%d/%m - %H:%M:%S",
+                   'Line 2 text (put format code e.g. "%d/%m - %H:%M:%S" for time rendering',
+                   "Line 2 text", "%d/%m - %H:%M:%S")
+    cfg.add_option('LCD_I2C', 'lcd_line_2_type', "Date_Time",
+                   "Line 2 type",
+                   "Line 2 type", ['Taken_Photo', 'Printed', 'Forgotten', 'Remaining_Duplicates', 'Date_Time', 'Text'])
+    cfg.add_option('LCD_I2C', 'lcd_line_3_text', "",
+                   'Line 3 text (put format code e.g. "%d/%m - %H:%M:%S" for time rendering',
+                   "Line 3 text", "")
+    cfg.add_option('LCD_I2C', 'lcd_line_3_type', "None",
+                   "Line 3 type",
+                   "Line 3 type", ['Taken_Photo', 'Printed', 'Forgotten', 'Remaining_Duplicates', 'Date_Time', 'Text'])
+    cfg.add_option('LCD_I2C', 'lcd_line_4_text', "",
+                   'Line 4 text (put format code e.g. "%d/%m - %H:%M:%S" for time rendering',
+                   "Line 4 text", "")
+    cfg.add_option('LCD_I2C', 'lcd_line_4_type', "None",
+                   "Line 4 type - Could be either Taken_Photo, Printed, Forgotten, Remaining_Duplicates, Date_Time, Text",
+                   "Line 4 type", ['Taken_Photo', 'Printed', 'Forgotten', 'Remaining_Duplicates', 'Date_Time', 'Text'])
 
-def write_date(app):
-    """Method called to write the Date on the screen
+
+def write_lcd_lines(app, specific_line_type="all"):
+    """Method called to write the lines on the screen
     """
     if hasattr(app, 'lcd'):
         try:
-            for line_index, line in enumerate(app.lines):
-                if "date_time" in line.split():
-                    app.lcd.cursor_pos = (line_index, 0)
-                    app.lcd.write_string(time.strftime(app.show_date_time))
-        except OSError:
-            pass
-
-
-def write_photo_count(app):
-    """Method called to write the Taken Photo on the screen
-    """
-    if hasattr(app, 'lcd'):
-        try:
-            for line_index, line in enumerate(app.lines):
-                if "taken_photo" in line.split():
+            for line_index, (line_text, line_type) in enumerate(app.lines):
+                if line_type == 'Taken_Photo' and specific_line_type in ['all', line_type]:
                     app.lcd.cursor_pos = (line_index, 0)
                     app.lcd.write_string(app.taken_photo_text[:app.cols - 4])
                     app.lcd.cursor_pos = (line_index, app.cols - 4)
                     app.lcd.write_string(' %s' % app.count.taken)
-        except OSError:
-            pass
-
-
-def write_printed_count(app):
-    """Method called to write the Printed Photo on the screen
-    """
-    if hasattr(app, 'lcd'):
-        try:
-            for line_index, line in enumerate(app.lines):
-                if "printed" in line.split():
+                elif line_type == 'Printed' and specific_line_type in ['all', line_type]:
                     app.lcd.cursor_pos = (line_index, 0)
                     app.lcd.write_string(app.printed_text[:app.cols - 4])
                     app.lcd.cursor_pos = (line_index, app.cols - 4)
                     app.lcd.write_string(' %s' % app.count.printed)
-        except OSError:
-            pass
-
-
-def write_forgotten_count(app):
-    """Method called to write the Forgotten Photo on the screen
-    """
-    if hasattr(app, 'lcd'):
-        try:
-            for line_index, line in enumerate(app.lines):
-                if "forgotten" in line.split():
+                elif line_type == 'Forgotten' and specific_line_type in ['all', line_type]:
                     app.lcd.cursor_pos = (line_index, 0)
-                    app.lcd.write_string(app.forgotten_text[:app.cols - 4])
+                    app.lcd.write_string(line_text[:app.cols - 4])
                     app.lcd.cursor_pos = (line_index, app.cols - 4)
                     app.lcd.write_string(' %s' % app.count.forgotten)
-        except OSError:
-            pass
-
-
-def write_remaining_duplicates_count(app):
-    """Method called to write the Remaining Duplicates Photo on the screen
-    """
-    if hasattr(app, 'lcd'):
-        try:
-            for line_index, line in enumerate(app.lines):
-                if "remaining_duplicates" in line.split():
+                elif line_type == 'Remaining_Duplicates' and specific_line_type in ['all', line_type]:
                     app.lcd.cursor_pos = (line_index, 0)
-                    app.lcd.write_string(app.remaining_duplicates_text[:app.cols - 4])
+                    app.lcd.write_string(line_text[:app.cols - 4])
                     app.lcd.cursor_pos = (line_index, app.cols - 4)
                     app.lcd.write_string(' %s' % app.count.remaining_duplicates)
-        except OSError:
-            pass
-
-
-def write_free_texts(app):
-    """Method called to write the Free-Texts on the screen
-    """
-    if hasattr(app, 'lcd'):
-        try:
-            for line_index, line in enumerate(app.lines):
-                if "free_text_{0}".format(line_index + 1) in line.split():
+                elif line_type == 'Date_Time' and specific_line_type in ['all', line_type]:
                     app.lcd.cursor_pos = (line_index, 0)
-                    app.lcd.write_string(app.free_texts[line_index][:app.cols])
+                    app.lcd.write_string(time.strftime(line_text))
+                elif line_type == 'Text' and specific_line_type in ['all', line_type]:
+                    app.lcd.cursor_pos = (line_index, 0)
+                    app.lcd.write_string(line_text[:app.cols])
         except OSError:
             pass
 
@@ -160,26 +107,11 @@ def connect_i2c(app, cfg):
         pass
 
     # line conf part
-    app.lines = [cfg.get('LCD_I2C', 'lcd_line_1').lower(),
-                 cfg.get('LCD_I2C', 'lcd_line_2').lower(),
-                 cfg.get('LCD_I2C', 'lcd_line_3').lower(),
-                 cfg.get('LCD_I2C', 'lcd_line_4').lower()]
+    app.lines = [(cfg.get('LCD_I2C', 'lcd_line_1_text'), cfg.get('LCD_I2C', 'lcd_line_1_type')),
+                 (cfg.get('LCD_I2C', 'lcd_line_2_text'), cfg.get('LCD_I2C', 'lcd_line_2_type')),
+                 (cfg.get('LCD_I2C', 'lcd_line_3_text'), cfg.get('LCD_I2C', 'lcd_line_3_type')),
+                 (cfg.get('LCD_I2C', 'lcd_line_4_text'), cfg.get('LCD_I2C', 'lcd_line_4_type'))]
 
-    # free text conf part
-    app.free_texts = [cfg.get('LCD_I2C', 'lcd_free_text1'),
-                      cfg.get('LCD_I2C', 'lcd_free_text2'),
-                      cfg.get('LCD_I2C', 'lcd_free_text3'),
-                      cfg.get('LCD_I2C', 'lcd_free_text4')]
-
-    # datetime conf part
-    app.show_date_time = cfg.get('LCD_I2C', 'lcd_show_date_time')
-    # counter text conf part
-    app.taken_photo_text = cfg.get('LCD_I2C', 'lcd_taken_photo_text')
-    app.printed_text = cfg.get('LCD_I2C', 'lcd_printed_text')
-    app.forgotten_text = cfg.get('LCD_I2C', 'lcd_forgotten_text')
-    app.remaining_duplicates_text = cfg.get('LCD_I2C', 'lcd_remaining_duplicates_text')
-
-# app.lcd = CharLCD(i2c_expander='PCF8574', address=0x3F, port=1, cols=16, rows=2, auto_linebreak=False, backlight_enabled=False)
 
 @pibooth.hookimpl
 def pibooth_startup(app, cfg):
@@ -187,29 +119,8 @@ def pibooth_startup(app, cfg):
     # startup.
     connect_i2c(app, cfg)
     
-    # Re-write the number of taken photo each time pibooth
-    # startup.
-    write_photo_count(app)
-
-    # Re-write the number of printed pictures each time pibooth
-    # startup.
-    write_printed_count(app)
-        
-    # Re-Write the number of forgotten pictures at pibooth
-    # startup
-    write_forgotten_count(app)
-
-    # Re-Write the number of remaining_duplicates at pibooth
-    # startup
-    write_remaining_duplicates_count(app)
-
-    # Re-Write the date/time at pibooth
-    # startup
-    write_date(app)
-    
-    # Write Free-Texts 
-    # startup.
-    write_free_texts(app)
+    # Write all lines at startup
+    write_lcd_lines(app)
 
 @pibooth.hookimpl
 def state_wait_enter(app, cfg):
@@ -217,124 +128,103 @@ def state_wait_enter(app, cfg):
     # enter in 'wait' state.
     connect_i2c(app, cfg)
 
-    # Re-write the number of taken pictures each time pibooth
-    # enter in 'wait' state.
-    write_photo_count(app)
-
-    # Re-write the number of printed pictures each time pibooth
-    # enter in 'wait' state.
-    write_printed_count(app)
-        
-    # Re-Write the number of forgotten pictures at pibooth
-    # enter in 'wait' state.
-    write_forgotten_count(app)
-
-    # Re-Write the number of remaining_duplicates at pibooth
-    # enter in 'wait' state.
-    write_remaining_duplicates_count(app)
-
-    # Re-Write the date at pibooth
-    # enter in 'wait' state.
-    write_date(app)
-    
-    # Write Free-Texts
-    # enter in 'wait' state.
-    write_free_texts(app)
+    # Write all lines at startup
+    write_lcd_lines(app)
 
 @pibooth.hookimpl
 def state_wait_do(app):
     # Re-Write the date at 'wait' do
-    write_date(app)
+    write_lcd_lines(app, specific_line_type="Date_Time")
 
 @pibooth.hookimpl
 def state_choose_enter(app):
     # Re-Write the date at chose do
-    write_date(app)
+    write_lcd_lines(app, specific_line_type="Date_Time")
 
 @pibooth.hookimpl
 def state_choose_do(app):
     # Re-Write the date at chose do
-    write_date(app)
+    write_lcd_lines(app, specific_line_type="Date_Time")
 
 @pibooth.hookimpl
 def state_chosen_do(app):
     # Re-Write the date at chosen do
-    write_date(app)
+    write_lcd_lines(app, specific_line_type="Date_Time")
 
 @pibooth.hookimpl
 def state_preview_enter(app):
     # Re-Write the date at preview_do
-    write_date(app)
+    write_lcd_lines(app, specific_line_type="Date_Time")
 
 @pibooth.hookimpl
 def state_preview_do(app):
     # Re-Write the date at preview_do
-    write_date(app)
+    write_lcd_lines(app, specific_line_type="Date_Time")
 
 @pibooth.hookimpl
 def state_preview_validate(app):
     # Re-Write the date at preview_validate
-    write_date(app)
+    write_lcd_lines(app, specific_line_type="Date_Time")
 
 @pibooth.hookimpl
 def state_preview_exit(app):
     # Re-Write the date at preview_exit
-    write_date(app)
+    write_lcd_lines(app, specific_line_type="Date_Time")
 
 @pibooth.hookimpl
 def state_capture_enter(app):
     # Re-Write the date at capture_enter
-    write_date(app)
+    write_lcd_lines(app, specific_line_type="Date_Time")
 
 @pibooth.hookimpl
 def state_capture_do(app):
     # Re-Write the date at capture_do
-    write_date(app)
+    write_lcd_lines(app, specific_line_type="Date_Time")
 
 @pibooth.hookimpl
 def state_capture_validate(app):
     # Re-Write the date at capture_validate
-    write_date(app)
+    write_lcd_lines(app, specific_line_type="Date_Time")
 
 @pibooth.hookimpl
 def state_capture_exit(app):
     # Re-Write the date at capture_exit
-    write_date(app)
+    write_lcd_lines(app, specific_line_type="Date_Time")
 
 @pibooth.hookimpl
 def state_processing_enter(app):
     # Re-Write the date at processing_enter
-    write_date(app)
+    write_lcd_lines(app, specific_line_type="Date_Time")
 
 @pibooth.hookimpl
 def state_processing_do(app):
     # Re-Write the date at processing_do
-    write_date(app)
+    write_lcd_lines(app, specific_line_type="Date_Time")
 
 @pibooth.hookimpl
 def state_processing_validate(app):
     # Re-Write the date at processing_validate
-    write_date(app)
+    write_lcd_lines(app, specific_line_type="Date_Time")
 
 @pibooth.hookimpl
 def state_processing_exit(app):
     # Re-Write the date at processing_exit
-    write_date(app)
+    write_lcd_lines(app, specific_line_type="Date_Time")
 
 @pibooth.hookimpl
 def state_print_do(app):
     # Re-Write the date at print_do
-    write_date(app)
+    write_lcd_lines(app, specific_line_type="Date_Time")
 
 @pibooth.hookimpl
 def state_finish_do(app):
     # Re-Write the date at finish_do
-    write_date(app)
+    write_lcd_lines(app, specific_line_type="Date_Time")
 
 @pibooth.hookimpl
 def state_failsafe_do(app):
     # Re-Write the date at failsafe_do
-    write_date(app)
+    write_lcd_lines(app, specific_line_type="Date_Time")
 
 @pibooth.hookimpl
 def pibooth_cleanup(app):

--- a/pibooth_lcd_i2c.py
+++ b/pibooth_lcd_i2c.py
@@ -60,31 +60,26 @@ def write_lcd_lines(app, specific_line_type="all"):
     if hasattr(app, 'lcd'):
         try:
             for line_index, (line_text, line_type) in enumerate(app.lines):
+                app.lcd.cursor_pos = (line_index, 0)
                 if line_type == 'Taken_Photo' and specific_line_type in ['all', line_type]:
-                    app.lcd.cursor_pos = (line_index, 0)
                     app.lcd.write_string(app.taken_photo_text[:app.cols - 4])
                     app.lcd.cursor_pos = (line_index, app.cols - 4)
                     app.lcd.write_string(' %s' % app.count.taken)
                 elif line_type == 'Printed' and specific_line_type in ['all', line_type]:
-                    app.lcd.cursor_pos = (line_index, 0)
                     app.lcd.write_string(app.printed_text[:app.cols - 4])
                     app.lcd.cursor_pos = (line_index, app.cols - 4)
                     app.lcd.write_string(' %s' % app.count.printed)
                 elif line_type == 'Forgotten' and specific_line_type in ['all', line_type]:
-                    app.lcd.cursor_pos = (line_index, 0)
                     app.lcd.write_string(line_text[:app.cols - 4])
                     app.lcd.cursor_pos = (line_index, app.cols - 4)
                     app.lcd.write_string(' %s' % app.count.forgotten)
                 elif line_type == 'Remaining_Duplicates' and specific_line_type in ['all', line_type]:
-                    app.lcd.cursor_pos = (line_index, 0)
                     app.lcd.write_string(line_text[:app.cols - 4])
                     app.lcd.cursor_pos = (line_index, app.cols - 4)
                     app.lcd.write_string(' %s' % app.count.remaining_duplicates)
                 elif line_type == 'Date_Time' and specific_line_type in ['all', line_type]:
-                    app.lcd.cursor_pos = (line_index, 0)
                     app.lcd.write_string(time.strftime(line_text))
                 elif line_type == 'Text' and specific_line_type in ['all', line_type]:
-                    app.lcd.cursor_pos = (line_index, 0)
                     app.lcd.write_string(line_text[:app.cols])
         except OSError:
             pass


### PR DESCRIPTION
Hey @DJ-Dingo here is the rework to avoid having 13 options for 4 lines.

Now for each line we have a text option and and a type option
- Text field is open, and can be configured in the menu
- Type shall be in ['Taken_Photo', 'Printed', 'Forgotten', 'Remaining_Duplicates', 'Date_Time', 'Text'] and cn also be configured through the menu.

Tell me if you find it easier to understand than the actual solution.

As for previous PR, I haven't tested it and I'm sure I made mistakes, good luck on the test.